### PR TITLE
fix: expand $VERSION in release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
 
           gh release create "$VERSION" \
             --title "claude-gate $VERSION" \
-            --notes "$(cat <<'EOF'
+            --notes "$(cat <<EOF
           ## Install
 
           ### Quick install (download binary)


### PR DESCRIPTION
## Summary
- Changed `<<'EOF'` to `<<EOF` in the release workflow so `$VERSION` gets shell-expanded in release notes instead of appearing literally

## Test plan
- [ ] Next release (v0.1.1+) should show actual version in install instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)