### PR TITLE
chore: remove Gitea references from rule configuration

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,42 +3,14 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
 
 jobs:
-  claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-      issues: read
-      id-token: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Run Claude Code Review
-        id: claude-review
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-
+  review:
+    uses: WastelandWares/.github/.github/workflows/claude-code-review.yml@main
+    secrets: inherit

--- a/Config/default-rules.toml
+++ b/Config/default-rules.toml
@@ -506,7 +506,7 @@ reason = "Sending messages via Slack is visible to others and hard to retract."
 risk = "high"
 
 [[rules]]
-name = "Gate: GitHub/Gitea API mutations"
+name = "Gate: GitHub API mutations"
 tool = "mcp__github__*"
 pattern = '(create|delete|update|merge|close|comment)'
 action = "gate"


### PR DESCRIPTION
## Summary
- Remove Gitea references from configuration and workflows
- Sync .github/workflows/ with main branch

## Test plan
- [ ] Verify no remaining gitea references
- [ ] Verify workflows match between main and _dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)